### PR TITLE
Fix Heading matching with #tags

### DIFF
--- a/Slimdown.php
+++ b/Slimdown.php
@@ -25,6 +25,7 @@ class Slimdown {
 	public static $rules = array (
 		'/```(.*?)```/s' => self::class .'::code_parse',                                                          // code blocks
 		'/\n(#+)(.*)/' => self::class .'::header',                                                                // headers
+		'/\n(#\s+)(.*)/' => self::class .'::header',                                                              // headers
 		'/\!\[([^\[]+)\]\(([^\)]+)\)/' => self::class .'::img',                                        // images
 		'/\[([^\[]+)\]\(([^\)]+)\)/' => self::class .'::link',                                                    // links
 		'/(\*\*|__)(?=(?:(?:[^`]*`[^`\r\n]*`)*[^`]*$))(?![^\/<]*>.*<\/.+>)(.*?)\1/' => '<strong>\2</strong>',     // bold


### PR DESCRIPTION
Now Heading needs to have a space between # and text, to avoid matching with #hashtags